### PR TITLE
Uses caret range specifier for dependencies that are above "major zero"

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -4,17 +4,17 @@
   "homepage": "https://github.com/perfectsense/brightspot-base",
   "dependencies": {
     "bsp-form": "perfectsense/brightspot-js-form#datepicker",
-    "bsp-utils": "perfectsense/brightspot-js-utils#3.0.0",
-    "bsp-carousel": "perfectsense/brightspot-js-carousel#1.0.0",
-    "bsp-share": "perfectsense/brightspot-js-share#3.0.0",
-    "bsp-templates": "perfectsense/brightspot-js-templates#2.0.5",
+    "bsp-utils": "perfectsense/brightspot-js-utils#^3.0.0",
+    "bsp-carousel": "perfectsense/brightspot-js-carousel#^1.0.0",
+    "bsp-share": "perfectsense/brightspot-js-share#^3.0.0",
+    "bsp-templates": "perfectsense/brightspot-js-templates#^2.0.5",
     "bsp-infinite-content": "perfectsense/brightspot-js-infinite-content#0.0.2",
     "bsp-toggle-item": "perfectsense/brightspot-js-toggle-item#0.0.1",
-    "bsp-feature-detect": "rustytanton/brightspot-js-feature-detect#brightspot-base",
-    "bootstrap": "3.3.4",
-    "fontawesome": "4.3.0",
-    "jquery": "2.1.4",
-    "bsp-tabber": "perfectsense/brightspot-js-tabber#~2.0.1"
+    "bsp-feature-detect": "perfectsense/brightspot-js-feature-detect#^1.0.0",
+    "bootstrap": "^3.3.4",
+    "fontawesome": "^4.3.0",
+    "jquery": "^2.1.4",
+    "bsp-tabber": "perfectsense/brightspot-js-tabber#^2.0.1"
   },
   "ignore": [
     "**/.*",

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "brightspot-base",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "homepage": "https://github.com/perfectsense/brightspot-base",
   "dependencies": {
     "bsp-form": "perfectsense/brightspot-js-form#datepicker",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "brightspot-base",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "devDependencies": {
     "babel-core": "^5.6.14",
     "bsp-grunt": "perfectsense/brightspot-js-grunt#2.0.3",


### PR DESCRIPTION
versions.
- Points to new (PSD) repo home for `brightspot-js-feature-detect`
- I'd like to propose we use caret `^` ranges for the modules as npm by default has switched to that range and it allows us to pickup minor and patch updates to these as we install & update.
