### PR TITLE
Adding Default Font Stack Variables

### DIFF
--- a/src/main/webapp/assets/styles/variables/typography.less
+++ b/src/main/webapp/assets/styles/variables/typography.less
@@ -1,6 +1,11 @@
 // Here we will call out the most frequently overriden variables for typography and create our own type scale
 // Bootstrap uses a type scale based on header tags, and instead we just use simple numbers vs tying it into h elements
 
+// Setting Default Font Stacks
+@font-family-sans-serif:    "Helvetica Neue", Helvetica, Arial, sans-serif;
+@font-family-serif:         Georgia, "Times New Roman", Times, serif;
+@font-family-monospace:     Menlo, Monaco, Consolas, "Courier New", monospace;
+
 // Base font family which is set on the body
 @font-family-base:      @font-family-sans-serif;
 


### PR DESCRIPTION
Removing the dependency from Bootstrap for default font stacks and putting them into base.
