### PR TITLE
Fixes displayOptions.modifierClass usage in the {{#each items}} loop

### DIFF
--- a/src/main/webapp/assets/templates/base/elements/list.hbs
+++ b/src/main/webapp/assets/templates/base/elements/list.hbs
@@ -7,6 +7,6 @@
 --}}
 <{{#if displayOptions.ordered}}ol{{else}}ul{{/if}} {{#if type}}type="{{type}}" {{/if}}class="{{#if displayOptions.unstyled}}unstyled-{{/if}}list{{#if displayOptions.inline}}-inline{{/if}}{{#if displayOptions.modifierClass}} {{displayOptions.modifierClass}}{{/if}}">
 	{{#each items}}
-		<li{{#if displayOptions.modifierClass}} {{displayOptions.modifierClass}}{{/if}}>{{render this}}</li>
+		<li{{#if displayOptions.modifierClass}} class="{{displayOptions.modifierClass}}"{{/if}}>{{render this}}</li>
 	{{/each}}
 </{{#if displayOptions.ordered}}ol{{else}}ul{{/if}}>


### PR DESCRIPTION
I noticed that the displayOptions.modifierClass usage was incorrect at the list item level (was missing the “class=“” wrapper).  This should fix that.
