### PR TITLE
Improve social share template and data

### DIFF
--- a/src/main/webapp/assets/templates/base/elements/social-share-item.hbs
+++ b/src/main/webapp/assets/templates/base/elements/social-share-item.hbs
@@ -1,0 +1,3 @@
+<li class="{{this.name}}-share">
+    {{#if renderLabel}}<span>{{this.name}}</span>{{/if}}
+</li>

--- a/src/main/webapp/assets/templates/base/elements/social-share.hbs
+++ b/src/main/webapp/assets/templates/base/elements/social-share.hbs
@@ -11,13 +11,20 @@
     			"redirectUrl":"{{redirectUrl}}",
     			"iconClass":"icon",
     			"serviceProps":{
-    				"facebook":{"appId":"{{facebookId}}"}
+					{{#each services}}
+						"{{this.name}}": { {{#if this.publicKey}}"appId": "{{this.publicKey}}"{{/if}} }
+						{{#unless @last}},{{/unless}}
+					{{/each}}
     			},
                 "sharingClass"       : "share-link",
                 "serviceClassBefore" : ""
     		}'>
 		{{#each services}}
-				<li class="{{this}}-share"></li>
+			{{#if ../displayOptions.renderLabel}}
+				{{render this renderLabel=true}}
+			{{else}}
+				{{this}}
+			{{/if}}
 		{{/each}}
 	</ul>
 </span>

--- a/styleguide/elements/social-share/share-monochrome-notitle.json
+++ b/styleguide/elements/social-share/share-monochrome-notitle.json
@@ -1,5 +1,5 @@
 {
-  
+
   "_template": "/assets/templates/base/elements/social-share",
 
   "displayOptions" : {
@@ -8,15 +8,27 @@
 
   "title": "Brightspot",
   "description": "A user experience platform, designed and developed to power large scale, highly dynamic, editorially rich and visually stunning experiences.",
-  "facebookId": 12345,
   "iconClass": "icon",
   "image": "http://www.brightspot.com/assets/brightspot.png",
   "url": "http://www.brightspot.com",
   "redirectUrl": "http://www.brightspot.com",
   "services": [
-    "facebook",
-    "twitter",
-    "pinterest",
-    "linkedin"
+    {
+      "_template": "/assets/templates/base/elements/social-share-item",
+      "name": "facebook",
+      "publicKey": 12345
+    },
+    {
+      "_template": "/assets/templates/base/elements/social-share-item",
+      "name": "twitter"
+    },
+    {
+      "_template": "/assets/templates/base/elements/social-share-item",
+      "name": "pinterest"
+    },
+    {
+      "_template": "/assets/templates/base/elements/social-share-item",
+      "name": "linkedin"
+    }
   ]
 }

--- a/styleguide/elements/social-share/share-monochrome.json
+++ b/styleguide/elements/social-share/share-monochrome.json
@@ -1,25 +1,34 @@
 {
-  
   "_template": "/assets/templates/base/elements/social-share",
-
-  "displayOptions" : {
+  "displayOptions": {
     "monochrome": true
-    },
+  },
   "socialTitle": {
     "_template": "/assets/templates/base/common/text",
-    "text" : "Share"
-    },
-
+    "text": "Share"
+  },
   "title": "Brightspot",
   "description": "A user experience platform, designed and developed to power large scale, highly dynamic, editorially rich and visually stunning experiences.",
-  "facebookId": 12345,
   "image": "http://www.brightspot.com/assets/brightspot.png",
   "url": "http://www.brightspot.com",
   "redirectUrl": "http://www.brightspot.com",
   "services": [
-    "facebook",
-    "twitter",
-    "pinterest",
-    "linkedin"
+    {
+      "_template": "/assets/templates/base/elements/social-share-item",
+      "name": "facebook",
+      "publicKey": 12345
+    },
+    {
+      "_template": "/assets/templates/base/elements/social-share-item",
+      "name": "twitter"
+    },
+    {
+      "_template": "/assets/templates/base/elements/social-share-item",
+      "name": "pinterest"
+    },
+    {
+      "_template": "/assets/templates/base/elements/social-share-item",
+      "name": "linkedin"
+    }
   ]
 }

--- a/styleguide/elements/social-share/share-render-label.json
+++ b/styleguide/elements/social-share/share-render-label.json
@@ -1,6 +1,8 @@
 {
-
   "_template": "/assets/templates/base/elements/social-share",
+  "displayOptions": {
+      "renderLabel": true
+  },
   "title": "Brightspot",
   "description": "A user experience platform, designed and developed to power large scale, highly dynamic, editorially rich and visually stunning experiences.",
   "image": "http://www.brightspot.com/assets/brightspot.png",

--- a/styleguide/elements/social-share/share.json
+++ b/styleguide/elements/social-share/share.json
@@ -1,20 +1,31 @@
 {
-  
   "_template": "/assets/templates/base/elements/social-share",
   "socialTitle": {
     "_template": "/assets/templates/base/common/text",
-    "text" : "Share"
-    },
+    "text": "Share"
+  },
   "title": "Brightspot",
   "description": "A user experience platform, designed and developed to power large scale, highly dynamic, editorially rich and visually stunning experiences.",
-  "facebookId": 12345,
   "image": "http://www.brightspot.com/assets/brightspot.png",
   "url": "http://www.brightspot.com",
   "redirectUrl": "http://www.brightspot.com",
   "services": [
-    "facebook",
-    "twitter",
-    "pinterest",
-    "linkedin"
+    {
+      "_template": "/assets/templates/base/elements/social-share-item",
+      "name": "facebook",
+      "publicKey": 12345
+    },
+    {
+      "_template": "/assets/templates/base/elements/social-share-item",
+      "name": "twitter"
+    },
+    {
+      "_template": "/assets/templates/base/elements/social-share-item",
+      "name": "pinterest"
+    },
+    {
+      "_template": "/assets/templates/base/elements/social-share-item",
+      "name": "linkedin"
+    }
   ]
 }


### PR DESCRIPTION
Refactors the data structure to support a list of service objects, each
one allowing a template/name/publicKey. This allows a way for us to
expanded upon those attributes (per social network) in the future;
whereas a list of strings does not. 

This is not a backwards compatible change. The corresponding view-model Java will need to be updated to provide a list of `objects` vs. `strings` to the `services` field. Each of the objects will need to be mapped to a new template renderer found in `/assets/templates/base/elements/social-share-item`. 
