### PR TITLE
Add example of overriding provider fields per service

### DIFF
--- a/src/main/webapp/assets/templates/base/elements/social-share.hbs
+++ b/src/main/webapp/assets/templates/base/elements/social-share.hbs
@@ -12,7 +12,12 @@
     			"iconClass":"icon",
     			"serviceProps":{
 					{{#each services}}
-						"{{this.name}}": { {{#if this.publicKey}}"appId": "{{this.publicKey}}"{{/if}} }
+						"{{this.name}}": {
+							{{#if this.publicKey}}"appId": "{{this.publicKey}}",{{/if}}
+							"title": "{{this.title}}",
+							"caption": "{{this.caption}}",
+							"description": "{{this.description}}"
+						}
 						{{#unless @last}},{{/unless}}
 					{{/each}}
     			},

--- a/styleguide/elements/social-share/share.json
+++ b/styleguide/elements/social-share/share.json
@@ -13,11 +13,13 @@
     {
       "_template": "/assets/templates/base/elements/social-share-item",
       "name": "facebook",
-      "publicKey": "123abc"
+      "publicKey": "abc123",
+      "caption": "My custom facebook caption"
     },
     {
       "_template": "/assets/templates/base/elements/social-share-item",
-      "name": "twitter"
+      "name": "twitter",
+      "title": "my custom twitter title"
     },
     {
       "_template": "/assets/templates/base/elements/social-share-item",

--- a/styleguide/elements/social-share/share.md
+++ b/styleguide/elements/social-share/share.md
@@ -1,0 +1,25 @@
+### Additional features:
+* Defining fields within each of the `services` will override the corresponding field in the parent data. For example:
+
+```
+"services": [
+    {
+        "_template": "/assets/templates/base/elements/social-share-item",
+        "name": "facebook",
+        "caption": "This value overrides the 'caption' value as defined in the parent data"
+    },
+    {
+        "_template": "/assets/templates/base/elements/social-share-item",
+        "name": "twitter",
+        "title": "This value overrides the 'title' value as defined in the parent data"
+    }
+    ...
+]
+```
+
+This gives the developer the ability to define the following specific values per service provider:
+* title
+* caption
+* description
+
+More information can be found in the plugin's documentation here: [Brightspot JS Share](https://github.com/perfectsense/brightspot-js-share)


### PR DESCRIPTION
![Example from Styleguide](https://cldup.com/pVgMPXbPyG.png)

Dependent on https://github.com/perfectsense/brightspot-js-share/pull/3, but should fail silently otherwise.
