### PR TITLE
Feature/mpx video

### DIFF
--- a/src/main/webapp/assets/templates/base/components/video-player.hbs
+++ b/src/main/webapp/assets/templates/base/components/video-player.hbs
@@ -53,13 +53,15 @@
                     {{/if}}
 
                     {{#if kaltura}}
-                        <div class="video-player-iframe-wrapper {{#with aspectRatio}}aspect-{{aspectRatio}}{{/with}}">
+                        <div class="video-player-iframe-wrapper {{#with aspectRatio}}aspect-{{this}}{{/with}}">
                             <iframe src="{{src}}{{#with querystring}}?{{render this}}{{/with}}" allowfullscreen frameborder="0"></iframe>
                         </div>
                     {{/if}}
 
                     {{#if mpx}}
-                        <iframe src="{{src}}" frameBorder="0" seamless="seamless" allowFullScreen></iframe>
+                        <div class="video-player-iframe-wrapper {{#with aspectRatio}}aspect-{{this}}{{/with}}">
+                            <iframe src="{{src}}" seamless="true" allowfullscreen frameborder="0"></iframe>
+                        </div>
                     {{/if}}
 
                 </div> {{!-- end of column --}}

--- a/src/main/webapp/assets/templates/base/components/video-player.hbs
+++ b/src/main/webapp/assets/templates/base/components/video-player.hbs
@@ -54,8 +54,12 @@
 
                     {{#if kaltura}}
                         <div class="video-player-iframe-wrapper {{#with aspectRatio}}aspect-{{aspectRatio}}{{/with}}">
-                            <iframe src="{{src}}{{#with querystring}}?{{render this}}{{/with}}" allowfullscreen webkitallowfullscreen mozAllowFullScreen frameborder="0"></iframe>
+                            <iframe src="{{src}}{{#with querystring}}?{{render this}}{{/with}}" allowfullscreen frameborder="0"></iframe>
                         </div>
+                    {{/if}}
+
+                    {{#if mpx}}
+                        <iframe src="{{src}}" frameBorder="0" seamless="seamless" allowFullScreen></iframe>
                     {{/if}}
 
                 </div> {{!-- end of column --}}

--- a/styleguide/components/video-player/mpx.json
+++ b/styleguide/components/video-player/mpx.json
@@ -1,5 +1,9 @@
 {
   "_template": "/assets/templates/base/components/video-player",
   "mpx": true,
-  "src": "http://player.theplatform.com/p/1X3jUC/_tfPjqHb_Oyz/select/vxF7_26USdi6?form=html"
+  "aspectRatio" : "16x9",
+  "src": "http://player.theplatform.com/p/1X3jUC/yh5o5S5hrJ4c/embed/select/vxF7_26USdi6?form=html",
+  "displayOptions": {
+      "align": "left"
+  }
 }

--- a/styleguide/components/video-player/mpx.json
+++ b/styleguide/components/video-player/mpx.json
@@ -2,8 +2,5 @@
   "_template": "/assets/templates/base/components/video-player",
   "mpx": true,
   "aspectRatio" : "16x9",
-  "src": "http://player.theplatform.com/p/1X3jUC/yh5o5S5hrJ4c/embed/select/vxF7_26USdi6?form=html",
-  "displayOptions": {
-      "align": "left"
-  }
+  "src": "http://player.theplatform.com/p/1X3jUC/yh5o5S5hrJ4c/embed/select/vxF7_26USdi6?form=html"
 }

--- a/styleguide/components/video-player/mpx.json
+++ b/styleguide/components/video-player/mpx.json
@@ -1,0 +1,5 @@
+{
+  "_template": "/assets/templates/base/components/video-player",
+  "mpx": true,
+  "src": "http://player.theplatform.com/p/1X3jUC/_tfPjqHb_Oyz/select/vxF7_26USdi6?form=html"
+}

--- a/styleguide/components/video-player/mpx.md
+++ b/styleguide/components/video-player/mpx.md
@@ -1,1 +1,10 @@
-ThePlatform's MPX player
+### ThePlatform's MPX player.
+### Dev Note:
+In order to render a video player that can be scaled to the size of its container, the `src` must contain `/embed/select/` between the "PlayerPID" and the video's "assetID"
+So, a URL like this:
+
+    http://player.theplatform.com/p/1X3jUC/yh5o5S5hrJ4c/vxF7_26USdi6?form=html
+
+Should be:
+
+    http://player.theplatform.com/p/1X3jUC/yh5o5S5hrJ4c/embed/select/vxF7_26USdi6?form=html

--- a/styleguide/components/video-player/mpx.md
+++ b/styleguide/components/video-player/mpx.md
@@ -1,4 +1,7 @@
-### ThePlatform's MPX player.
+### ThePlatform's MPX player
+
+[PDK Docs](http://help.theplatform.com/display/pdk/)
+
 ### Dev Note:
 In order to render a video player that can be scaled to the size of its container, the `src` must contain `/embed/select/` between the "PlayerPID" and the video's "assetID"
 So, a URL like this:

--- a/styleguide/components/video-player/mpx.md
+++ b/styleguide/components/video-player/mpx.md
@@ -1,0 +1,1 @@
+ThePlatform's MPX player


### PR DESCRIPTION
This allows MPX video to be rendered in an `iframe` via `mpx: true` in the ViewData.
