### PR TITLE
BSP-2404: Sample style groundwork

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -7,7 +7,8 @@ module.exports = function (grunt) {
             styles: {
                 dir: '',
                 less: [
-                    'base/All.less'
+                    'base/All.less',
+                    'base/sample/All.less'
                 ],
                 options : {
                     autoprefixer: true

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -8,7 +8,7 @@ module.exports = function (grunt) {
                 dir: '',
                 less: [
                     'base/All.less',
-                    'base/sample/All.less'
+                    'sample/All.less'
                 ],
                 options : {
                     autoprefixer: true

--- a/src/main/webapp/base/sample/All.less
+++ b/src/main/webapp/base/sample/All.less
@@ -1,0 +1,1 @@
+@import "../All.less";

--- a/src/main/webapp/base/sample/All.less
+++ b/src/main/webapp/base/sample/All.less
@@ -1,1 +1,0 @@
-@import "../All.less";

--- a/src/main/webapp/sample/All.less
+++ b/src/main/webapp/sample/All.less
@@ -1,0 +1,1 @@
+@import "../base/All.less";

--- a/styleguide/_config.json
+++ b/styleguide/_config.json
@@ -3,6 +3,10 @@
         {
             "name": "Base",
             "href": "/base/All.min.css"
+        },
+        {
+            "name": "Samples",
+            "href": "/base/sample/All.min.css"
         }
     ]
 }

--- a/styleguide/_config.json
+++ b/styleguide/_config.json
@@ -6,7 +6,7 @@
         },
         {
             "name": "Samples",
-            "href": "/base/sample/All.min.css"
+            "href": "/sample/All.min.css"
         }
     ]
 }


### PR DESCRIPTION
A baseline for adding Sample styles. There's a related styleguide improvement here (https://github.com/perfectsense/brightspot-styleguide/pull/48) that supports this update.
