### PR TITLE
GalleryMain - Add wrapper around media controls and content

### DIFF
--- a/src/main/webapp/base/GallerySlide.hbs
+++ b/src/main/webapp/base/GallerySlide.hbs
@@ -16,8 +16,10 @@
 
     {{#defineElement "media" noWith=true}}
         <div class="{{elementName}}">
-            {{element "mediaControls"}}
-            {{element "mediaContent"}}
+            <div class="{{elementName}}Container">
+                {{element "mediaControls"}}
+                {{element "mediaContent"}}
+            </div>
         </div>
     {{/defineElement}}
 


### PR DESCRIPTION
Fix for the following bug: The Zoom button should always be in the top right corner of the `image`, and not in the top right corner of the `cell`. It is in the correct place for the horizontal images on Desktop. The bug is seen when you have the vertical images on Desktop, falling outside of the image.
