### PR TITLE
BEX-172: Listicle

### DIFF
--- a/styleguide/core/All.less
+++ b/styleguide/core/All.less
@@ -11,8 +11,8 @@
 @import 'GallerySlide';
 @import 'Input';
 @import 'Image';
-@import 'ListicleMain';
 @import 'ListicleItem';
+@import 'ListicleMain';
 @import 'ListPromo';
 @import 'Main';
 @import 'MediaPromo';

--- a/styleguide/core/All.less
+++ b/styleguide/core/All.less
@@ -11,6 +11,8 @@
 @import 'GallerySlide';
 @import 'Input';
 @import 'Image';
+@import 'ListicleMain';
+@import 'ListicleItem';
 @import 'ListPromo';
 @import 'Main';
 @import 'MediaPromo';

--- a/styleguide/core/ListicleItem.hbs
+++ b/styleguide/core/ListicleItem.hbs
@@ -1,0 +1,24 @@
+{{#defineBlock "ListicleItem"}}
+
+    {{#defineElement "headline"}}
+        <div class="{{elementName}}" itemprop="name">{{this}}</div>
+    {{/defineElement}}
+
+    {{#defineElement "description"}}
+        <div class="{{elementName}}" itemprop="description">{{this}}</div>
+    {{/defineElement}}
+
+    {{#defineElement "image"}}
+        <div class="{{elementName}}" itemprop="image">{{this}}</div>
+    {{/defineElement}}
+    
+    {{#defineBlockContainer}}
+        <li class="{{blockName}}" itemprop="itemListElement" itemscope itemtype="http://schema.org/ListItem">
+            {{#defineBlockBody}}
+                {{element "headline"}}
+                {{element "description"}}
+                {{element "image"}}               
+            {{/defineBlockBody}}
+        </li>
+    {{/defineBlockContainer}}
+{{/defineBlock}}

--- a/styleguide/core/ListicleItem.hbs
+++ b/styleguide/core/ListicleItem.hbs
@@ -13,12 +13,12 @@
     {{/defineElement}}
     
     {{#defineBlockContainer}}
-        <li class="{{blockName}}" itemprop="itemListElement" itemscope itemtype="http://schema.org/ListItem">
+        <div class="{{blockName}}" itemprop="itemListElement" itemscope itemtype="http://schema.org/ListItem">
             {{#defineBlockBody}}
                 {{element "headline"}}
                 {{element "description"}}
                 {{element "image"}}               
             {{/defineBlockBody}}
-        </li>
+        </div>
     {{/defineBlockContainer}}
 {{/defineBlock}}

--- a/styleguide/core/ListicleItem.json
+++ b/styleguide/core/ListicleItem.json
@@ -1,0 +1,8 @@
+{
+    "_template": "ListicleItem.hbs",
+    "headline": "{{words(8,12)}}",
+    "description": "{{words(20,40)}}",
+    "image": {
+        "_dataUrl": "Figure.json"
+    }
+}

--- a/styleguide/core/ListicleItem.less
+++ b/styleguide/core/ListicleItem.less
@@ -1,0 +1,14 @@
+.ListicleItem {
+    
+    &-headline {
+        &:extend(.ListicleItem-headline all);
+    }
+
+    &-description {
+        &:extend(.ListicleItem-description all);
+    }
+
+    &-image {
+        &:extend(.ListicleItem-image all);
+    }
+}

--- a/styleguide/core/ListicleMain.hbs
+++ b/styleguide/core/ListicleMain.hbs
@@ -1,0 +1,40 @@
+{{#defineBlock "Listicle" extend="ArticleMain.hbs"}}
+
+    {{#defineElement "items"}}
+        {{#if ../ordered}}
+            <ol class="{{elementName}}" itemscope itemtype="http://schema.org/ItemList"{{#if ../reversed}} reversed{{/if}}>
+                {{#each this}}
+                    {{this}}
+                {{/each}}
+            </ol>
+        {{else}}
+            <ul class="{{elementName}}" itemprop="articleBody" itemtype="http://schema.org/ItemList">
+                {{#each this}}
+                    {{this}}
+                {{/each}}
+            </ul>
+        {{/if}}
+    {{/defineElement}}
+
+    {{#defineBlockContainer}}
+        <article class="{{blockName}}" itemprop="mainEntity" itemscope itemtype="http://schema.org/Article"{{extraAttributes}}>
+            {{element "meta"}}
+
+            {{#defineBlockBody}}
+                {{element "breadcrumbs"}}
+                {{element "preHeadline"}}
+                {{element "headline"}}
+                {{element "subHeadline"}}
+                {{element "byline"}}
+                {{element "authors"}}
+                {{element "datePublished"}}
+                {{element "dateModified"}}
+                {{element "lead"}}
+                {{element "items"}}
+                {{element "tags"}}
+                {{element "sharebar"}}
+                {{element "comments"}}
+            {{/defineBlockBody}}
+        </article>
+    {{/defineBlockContainer}}
+{{/defineBlock}}

--- a/styleguide/core/ListicleMain.hbs
+++ b/styleguide/core/ListicleMain.hbs
@@ -2,22 +2,26 @@
 
     {{#defineElement "items"}}
         {{#if ../ordered}}
-            <ol class="{{elementName}}" itemscope itemtype="http://schema.org/ItemList"{{#if ../reversed}} reversed{{/if}}>
+            <ol class="{{elementName}}" {{#if ../reversed}} reversed{{/if}}>
                 {{#each this}}
+                    <li class="{{elementName}}-item">
                     {{this}}
+                    </li>
                 {{/each}}
             </ol>
         {{else}}
-            <ul class="{{elementName}}" itemscope itemtype="http://schema.org/ItemList">
+            <ul class="{{elementName}}">
                 {{#each this}}
-                    {{this}}
+                    <li class="{{elementName}}-item">
+                        {{this}}
+                    <li>
                 {{/each}}
             </ul>
         {{/if}}
     {{/defineElement}}
 
     {{#defineBlockContainer}}
-        <article class="{{blockName}}" itemprop="mainEntity" itemscope itemtype="http://schema.org/Article"{{extraAttributes}}>
+        <article class="{{blockName}}" itemprop="mainEntity" itemscope itemtype="http://schema.org/Article http://schema.org/ItemList"{{extraAttributes}}>
             {{element "meta"}}
 
             {{#defineBlockBody}}

--- a/styleguide/core/ListicleMain.hbs
+++ b/styleguide/core/ListicleMain.hbs
@@ -8,7 +8,7 @@
                 {{/each}}
             </ol>
         {{else}}
-            <ul class="{{elementName}}" itemprop="articleBody" itemtype="http://schema.org/ItemList">
+            <ul class="{{elementName}}" itemscope itemtype="http://schema.org/ItemList">
                 {{#each this}}
                     {{this}}
                 {{/each}}

--- a/styleguide/core/ListicleMain.json
+++ b/styleguide/core/ListicleMain.json
@@ -1,0 +1,59 @@
+{
+    "_template": "ListicleMain.hbs",
+
+    "datePublished": "Published: December 11, 2016",
+    "datePublishedISO": "2016-02-19T16:43:22+00:00",
+    "dateModified": "Modified: December 12, 2016",
+    "dateModifiedISO": "2016-02-19T17:44:23+00:00",
+
+    "breadcrumbs": {
+        "_dataUrl": "Breadcrumbs.json"
+    },
+
+    "preHeadline": "Exploration",
+    "headline": "After Many Years and 17 Cities, a Pilot Realizes His Dream Journey",
+    "subHeadline": "Flying Around the World Without a Drop of Fossil Fuel",
+    "byline": "By:",
+
+    "authors": {
+        "_dataUrl": "Author.json"
+    },
+
+    "lead": {
+        "_dataUrl": "Image.json",
+        "src": "{{image(900,450)}}",
+        "width": 900,
+        "height": 450
+    },
+
+    "items": [
+        {
+            "_dataUrl": "ListicleItem.json",
+            "_repeat": [5, 10]
+        }
+    ],
+    "ordered": true,
+    "reversed": true,
+
+    "tags": {
+        "_template": "Concatenated.hbs",
+        "delimiter": ",",
+        "items": [
+            {
+                "_template": "Link.hbs",
+                "href": "#",
+                "body": "Tag 1"
+            },
+            {
+                "_template": "Link.hbs",
+                "href": "#",
+                "body": "Tag 2"
+            },
+            {
+                "_template": "Link.hbs",
+                "href": "#",
+                "body": "Tag 3"
+            }
+        ]
+    }
+}

--- a/styleguide/core/ListicleMain.less
+++ b/styleguide/core/ListicleMain.less
@@ -1,0 +1,15 @@
+@import 'ArticleMain';
+
+.ListicleMain {
+    &:extend(.ArticleMain all);
+
+    &-items {
+        &:extend(.ListicleMain-items all);
+    }
+
+    & when (@_demo) {
+        &-items {
+            ._Block;
+        }
+    }
+}


### PR DESCRIPTION
In schema.org markup, the closest thing to `Listicle` appeared to be a combination of  `itemtype` [Article](https://schema.org/Article) and [ItemList](https://schema.org/ItemList). A similar example of this can be found in the ItemList spec for example 4. 

Each `ListicleItem` contains the schema.org markup for a [ListItem](https://schema.org/ListItem).